### PR TITLE
Dep/api fx

### DIFF
--- a/src/app/dash/researcher/page.tsx
+++ b/src/app/dash/researcher/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import DropDown from "@/components/UI/dropDown";
 import { useQuery } from "@tanstack/react-query";
 import { logout } from "@/utils/auth";
+import { apiFetch } from "@/utils/api";
 
 export default function ResearcherDashboard() {
   const router = useRouter();
@@ -19,7 +20,7 @@ export default function ResearcherDashboard() {
   const [loginOpen, setLoginOpen] = useState(false);
 
   const getCurrentUserEmail = async (token) => {
-    const res = await fetch("/api/auth/me", {
+    const res = await apiFetch("/api/auth/me", {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/app/dash/staff/page.tsx
+++ b/src/app/dash/staff/page.tsx
@@ -18,6 +18,7 @@ import ConfigView from "@/components/Dashboard/ConfigView";
 import { ResearcherConfig, ResearcherResults } from "@/schemas/dashSchemas";
 import DropDown from "@/components/UI/dropDown";
 import { logout } from "@/utils/auth";
+import { apiFetch } from "@/utils/api";
 
 export default function StaffDashboard() {
   const router = useRouter();
@@ -44,7 +45,7 @@ export default function StaffDashboard() {
   const [loginOpen, setLoginOpen] = useState(false);
 
   const getCurrentUserEmail = async (token) => {
-    const res = await fetch("/api/auth/me", {
+    const res = await apiFetch("/api/auth/me", {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ErrorDisplay from "@/components/UserView/Error";
+import { apiFetch } from "@/utils/api";
 import { useState } from "react";
 
 export default function TestPage() {
@@ -9,7 +10,7 @@ export default function TestPage() {
   const handleClick = async () => {
     setSent(true);
     const body = { post: "ok" };
-    const res = await fetch(`/api`, {
+    const res = await apiFetch(`/api`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),

--- a/src/components/StudyRetrieval.tsx
+++ b/src/components/StudyRetrieval.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { v4 as uuidv4 } from "uuid"
 import { study_code_len } from "@/schemas/const";
+import { apiFetch } from "@/utils/api";
 
 const codeFormModel = z.object({
     studyCode: z.string().nonempty("Code Required").length(study_code_len)
@@ -33,7 +34,7 @@ export default function StudyRetrieval() {
 
         //If Succesfully Parsed
         if (result.success) {
-            const res = await fetch(`/api/study/study_id/${result.data.studyCode}`, { method: "GET" });
+            const res = await apiFetch(`/api/study/study_id/${result.data.studyCode}`, { method: "GET" });
             if (!res.ok)
                 throw new Error("Unable to Find Study")
 

--- a/src/components/UserView/SurveyForm/SurveyForm.tsx
+++ b/src/components/UserView/SurveyForm/SurveyForm.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { z } from "zod";
 import ErrorDisplay from "../Error";
+import { apiFetch } from "@/utils/api";
 // import toast from "react-hot-toast";
 
 const genderOptions = [
@@ -64,7 +65,7 @@ export default function SurveyForm({ subjectID }: { subjectID: string }) {
             race: result.data.race === "Multiracial" ? result.data.raceOther : result.data.race,
         };
 
-        const res = await fetch(`/api/survey/responses`, {
+        const res = await apiFetch(`/api/survey/responses`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,6 @@ import { MiddlewareConfig, NextRequest, NextResponse } from "next/server";
 export function middleware(req: NextRequest) {
     if (req.nextUrl.pathname.startsWith("/api")) {
         const backendUrl = process.env.NEXT_PUBLIC_API_URL;
-        console.log("Rewriting to backend:", backendUrl + req.nextUrl.pathname.replace("/api", "") + req.nextUrl.search);
         return NextResponse.rewrite(new URL(
             `${backendUrl}${req.nextUrl.pathname.replace("/api", "")}${req.nextUrl.search}`
         ), { request: req })

--- a/src/utils/api.tsx
+++ b/src/utils/api.tsx
@@ -1,0 +1,4 @@
+export const apiFetch = (path: string, options: RequestInit = {}) => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  return fetch(`${baseUrl}${path}`, options);
+};

--- a/src/utils/api.tsx
+++ b/src/utils/api.tsx
@@ -1,4 +1,5 @@
 export const apiFetch = (path: string, options: RequestInit = {}) => {
   const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-  return fetch(`${baseUrl}${path}`, options);
+  const normalizedPath = path.startsWith("/api") ? path.replace(/^\/api/, "") : path;
+  return fetch(`${baseUrl}${normalizedPath}`, options);
 };

--- a/src/utils/auth/index.ts
+++ b/src/utils/auth/index.ts
@@ -1,4 +1,5 @@
 import { LoginResponse, loginResponseModel } from "@/schemas/authSchemas";
+import { apiFetch } from "../api";
 
 export const getAuthToken = async ({
   username,
@@ -11,7 +12,7 @@ export const getAuthToken = async ({
   formData.append("username", username);
   formData.append("password", password);
 
-  const res = await fetch("api/auth/jwt/login", {
+  const res = await apiFetch("api/auth/jwt/login", {
     method: "POST",
     body: formData,
   });
@@ -34,7 +35,7 @@ export const registerUser = async ({
   password: string;
   confirmPassword: string;
 }) => {
-  const res = await fetch("/api/auth/register", {
+  const res = await apiFetch("/api/auth/register", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -55,7 +56,7 @@ export const registerUser = async ({
 };
 
 export const logout = async (token: string | undefined) => {
-  const res = await fetch("/api/auth/jwt/logout", {
+  const res = await apiFetch("/api/auth/jwt/logout", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/src/utils/conclusionPhase/hooks.ts
+++ b/src/utils/conclusionPhase/hooks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../api";
 
 type ConclusionPhaseConfig = {
     has_survey: boolean;
@@ -11,7 +12,7 @@ export function useConclusionPhase(studyID: string | undefined) {
         queryKey: ["conclusionPhase", studyID],
         enabled: !!studyID,
         queryFn: async () => {
-            const res = await fetch(`/api/study/export/${studyID}`);
+            const res = await apiFetch(`/api/study/export/${studyID}`);
             if (!res.ok) {
                 throw new Error("Failed to fetch conclusion phase config");
             }

--- a/src/utils/configUpload/index.ts
+++ b/src/utils/configUpload/index.ts
@@ -1,4 +1,5 @@
 import { ConfigSettings } from "@/schemas/studyConfigSchemas";
+import { apiFetch } from "../api";
 
 //Flattens data and maps it to FastAPI Aliases
 function appendToFormData(formData: FormData, config: ConfigSettings) {
@@ -39,7 +40,7 @@ export const uploadConfig = (async (config: ConfigSettings, token:string | undef
     const formData = new FormData();
     appendToFormData(formData, config);
 
-    const res = await fetch(`/api/config/save`, {
+    const res = await apiFetch(`/api/config/save`, {
         method: "POST",
         body: formData,
         headers:{
@@ -55,7 +56,7 @@ export const uploadConfig = (async (config: ConfigSettings, token:string | undef
 });
 
 export const getStudyConfig = (async (studyID: string) => {
-    const res = await fetch(`/api/study/export/${studyID}`, {
+    const res = await apiFetch(`/api/study/export/${studyID}`, {
         method: "GET",
     });
     if (!res.ok) {

--- a/src/utils/dash/index.ts
+++ b/src/utils/dash/index.ts
@@ -1,5 +1,7 @@
+import { apiFetch } from "../api";
+
 export const fetchUserRole = async (token: string | undefined) => {
-    const res = await fetch(`/api/user/role`, {
+    const res = await apiFetch(`/api/user/role`, {
         method: "GET",
         headers: {
             Authorization: `Bearer ${token}`

--- a/src/utils/dash/researcher/index.ts
+++ b/src/utils/dash/researcher/index.ts
@@ -1,5 +1,7 @@
+import { apiFetch } from "@/utils/api";
+
 export const getResearcherConfig = async (token: string | undefined) => {
-  const res = await fetch(`/api/researcher/configurations`, {
+  const res = await apiFetch(`/api/researcher/configurations`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -15,7 +17,7 @@ export const getResearcherConfig = async (token: string | undefined) => {
 };
 
 export const getResearcherResults = async (token: string | undefined) => {
-  const res = await fetch(`/api/researcher/results`, {
+  const res = await apiFetch(`/api/researcher/results`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -34,7 +36,7 @@ export const getStudyResults = async (
   token: string | undefined,
   resultsID: string
 ) => {
-  const res = await fetch(`/api/researcher/export/${resultsID}`, {
+  const res = await apiFetch(`/api/researcher/export/${resultsID}`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -51,7 +53,7 @@ export const getStudyResults = async (
 export const getAllStudyResults = async (
   token: string | undefined
 ) => {
-  const res = await fetch(`/api/researcher/export_all`, {
+  const res = await apiFetch(`/api/researcher/export_all`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -69,7 +71,7 @@ export const deleteImage = async (
   token: string | undefined,
   filename: string
 ) => {
-  const res = await fetch(`/api/images/delete_file`, {
+  const res = await apiFetch(`/api/images/delete_file`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
@@ -87,7 +89,7 @@ export const deleteImage = async (
 };
 
 export const deleteConfig = async (token: string | undefined, study_code:string) => {
-  const res = await fetch(`/api/researcher/delete/config`, {
+  const res = await apiFetch(`/api/researcher/delete/config`, {
     method: "DELETE",
         headers: {
             'Content-Type': 'application/json',
@@ -102,7 +104,7 @@ export const deleteConfig = async (token: string | undefined, study_code:string)
 };
 
 export const deleteResult = async (token: string | undefined, result_id:string) => {
-  const res = await fetch(`/api/researcher/delete/result`, {
+  const res = await apiFetch(`/api/researcher/delete/result`, {
     method: "DELETE",
         headers: {
             'Content-Type': 'application/json',

--- a/src/utils/dash/staff/hooks.tsx
+++ b/src/utils/dash/staff/hooks.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from "jotai";
 import { tokenAtom } from "@/utils/auth/store";
 import { ImagePage, ResearcherConfig, ResearcherResults } from "@/schemas/dashSchemas";
 import { AwsS3Part } from "@uppy/aws-s3";
+import { apiFetch } from "@/utils/api";
 
 export const useGetImageData = (next: string | null) => {
   const token = useAtomValue(tokenAtom);
@@ -63,7 +64,7 @@ export const createMPU = async (
   token: string | undefined,
   file: { name: string; type: string; size: number }
 ) => {
-  const res = await fetch(`/api/images/s3-multipart/create`, {
+  const res = await apiFetch(`/api/images/s3-multipart/create`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -87,7 +88,7 @@ export const signPart = async ({
   key: string;
   partNumber: number;
 }) => {
-  const res = await fetch(`/api/images/s3-multipart/sign-part`, {
+  const res = await apiFetch(`/api/images/s3-multipart/sign-part`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -114,7 +115,7 @@ export const completeMPU = async (
     parts: AwsS3Part[];
   }
 ) => {
-  const res = await fetch(`/api/images/s3-multipart/complete`, {
+  const res = await apiFetch(`/api/images/s3-multipart/complete`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -136,7 +137,7 @@ export const abortMPU = async ({
   uploadId: string | undefined;
   key: string;
 }) => {
-  const res = await fetch(`/api/images/s3-multipart/abort`, {
+  const res = await apiFetch(`/api/images/s3-multipart/abort`, {
     method: "POST",
     headers: {
       "content-type": "application/json",

--- a/src/utils/dash/staff/index.ts
+++ b/src/utils/dash/staff/index.ts
@@ -1,8 +1,10 @@
+import { apiFetch } from "@/utils/api";
+
 export const getImageData = async (
   token: string | undefined,
   next: string | null
 ) => {
-  const res = await fetch(
+  const res = await apiFetch(
     `/api/images/get_file_page${
       next ? `?next_token=${encodeURIComponent(next)}` : ""
     }`,
@@ -30,7 +32,7 @@ export const deleteImage = async (
   token: string | undefined,
   filename: string
 ) => {
-  const res = await fetch(`/api/images/delete_file`, {
+  const res = await apiFetch(`/api/images/delete_file`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
@@ -51,7 +53,7 @@ export const uploadFile = async (token: string | undefined, file: File) => {
   const formData = new FormData();
   formData.append("file", file);
 
-  const res = await fetch(`/api/images/upload`, {
+  const res = await apiFetch(`/api/images/upload`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -71,7 +73,7 @@ export const getStaffResearcherResults = async (
   token: string | undefined,
   email: string
 ) => {
-  const res = await fetch(`/api/staff/search/results`, {
+  const res = await apiFetch(`/api/staff/search/results`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -91,7 +93,7 @@ export const getStaffResearcherConfigs= async (
   token: string | undefined,
   email: string
 ) => {
-  const res = await fetch(`/api/staff/search/configs`, {
+  const res = await apiFetch(`/api/staff/search/configs`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/utils/experimentPhase/hooks.ts
+++ b/src/utils/experimentPhase/hooks.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { StudyResponseList } from "@/schemas/studyResponseSchemas";
 import { submitAnswers } from ".";
+import { apiFetch } from "../api";
 
 export const useSubmitExperimentAnswers = () => {
     return useMutation({
@@ -20,7 +21,7 @@ export function useExperimentPhaseConfig(studyID: string) {
     return useQuery({
         queryKey: ["experimentPhaseConfig", studyID],
         queryFn: async () => {
-            const res = await fetch(`/api/study/experiment_phase/${studyID}`);
+            const res = await apiFetch(`/api/study/experiment_phase/${studyID}`);
             if (!res.ok) throw new Error("Failed to fetch experiment phase config");
             return res.json(); // { display_duration, pause_duration, display_method, scoring_method, image_urls }
         },

--- a/src/utils/experimentPhase/index.ts
+++ b/src/utils/experimentPhase/index.ts
@@ -1,4 +1,5 @@
 import { StudyResponseList } from "@/schemas/studyResponseSchemas";
+import { apiFetch } from "../api";
 
 export const submitAnswers = (async (configID:string, subjectID:string, answers: StudyResponseList) => {
     const body={
@@ -8,7 +9,7 @@ export const submitAnswers = (async (configID:string, subjectID:string, answers:
         },
         "responses":answers
     }
-    const res = await fetch(`/api/results/responses`, {
+    const res = await apiFetch(`/api/results/responses`, {
         method: "POST",
         headers:{ "Content-Type": "application/json",},
         body: JSON.stringify(body)

--- a/src/utils/fileRetrieval/index.ts
+++ b/src/utils/fileRetrieval/index.ts
@@ -1,6 +1,8 @@
+import { apiFetch } from "../api";
+
 //GET FILES
 export const getFile = (async (studyID:string, file:string) => {
-    const res = await fetch(`/api/study/${file}/${studyID}`, {
+    const res = await apiFetch(`/api/study/${file}/${studyID}`, {
         method: "GET"
 });
 

--- a/src/utils/learningPhase/hooks.ts
+++ b/src/utils/learningPhase/hooks.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../api";
 
 export function useLearningPhaseConfig(studyID: string) {
     return useQuery({
         queryKey: ["learningPhaseConfig", studyID],
         queryFn: async () => {
-            const res = await fetch(`/api/study/learning_phase/${studyID}`);
+            const res = await apiFetch(`/api/study/learning_phase/${studyID}`);
             if (!res.ok) throw new Error("Failed to fetch learning phase config");
 
             const config = await res.json();

--- a/src/utils/studyRetrieval/index.ts
+++ b/src/utils/studyRetrieval/index.ts
@@ -1,5 +1,7 @@
+import { apiFetch } from "../api";
+
 export const getStudyID = (async (studyCode: string) => {
-    const res = await fetch(`/api/study/study_id/${studyCode}`, {
+    const res = await apiFetch(`/api/study/study_id/${studyCode}`, {
         method: "GET",
     });
     if (!res.ok) {

--- a/src/utils/waitphase/hooks.ts
+++ b/src/utils/waitphase/hooks.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "../api";
 
 export function useWaitPhaseConfig(studyID: string) {
     return useQuery({
         queryKey: ["waitPhaseConfig", studyID],
         queryFn: async () => {
-            const res = await fetch(`/api/study/waiting_phase/${studyID}`);
+            const res = await apiFetch(`/api/study/waiting_phase/${studyID}`);
             if (!res.ok) throw new Error("Failed to fetch wait phase config");
             return res.json(); // Expected response: { wait_duration, show_spinner, ... }
         },


### PR DESCRIPTION
Added helper function that ingests the fetch request url path, strips the `/api` and adds the env path to it. Apparently this is necessary for static sites since using `next: export` removes middleware.